### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 
 		"illuminate/config": "4.1.x",
 		"illuminate/queue": "4.1.x",
-		"chrisboulton/php-resque": "dev-master"
+		"chrisboulton/php-resque": "1.2.x"
 	},
 	"suggest": {
 		"chrisboulton/php-resque-scheduler": "Enables the use of the ResqueScheduler functionality."


### PR DESCRIPTION
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - awellis13/laravel-resque 1.2.2 requires chrisboulton/php-resque dev-master -> no matching package found.
    - awellis13/laravel-resque 1.2.1 requires chrisboulton/php-resque dev-master -> no matching package found.
    - awellis13/laravel-resque 1.2.0 requires php >=5.5.0 -> no matching package found.
    - Installation request for awellis13/laravel-resque 1.2.x -> satisfiable by awellis13/laravel-resque[1.2.0, 1.2.1, 1.2.2].

Potential causes:
- A typo in the package name
- The package is not available in a stable-enough version according to your minimum-stability setting
  see https://groups.google.com/d/topic/composer-dev/_g3ASeIFlrc/discussion for more details.

Read http://getcomposer.org/doc/articles/troubleshooting.md for further common problems.
